### PR TITLE
aw88261: fix erroneous mask logic for SYSCTRL register initialization

### DIFF
--- a/sound/soc/codecs/aw88261.c
+++ b/sound/soc/codecs/aw88261.c
@@ -424,9 +424,11 @@ static int aw88261_dev_reg_update(struct aw88261 *aw88261,
 			if (ret)
 				break;
 
+			/* keep all three bits from current hw status */
 			read_val &= (~AW88261_AMPPD_MASK) | (~AW88261_PWDN_MASK) |
 								(~AW88261_HMUTE_MASK);
-			reg_val &= (AW88261_AMPPD_MASK | AW88261_PWDN_MASK | AW88261_HMUTE_MASK);
+			/* the masks below and above this line are complementary */
+			reg_val &= (AW88261_AMPPD_MASK & AW88261_PWDN_MASK & AW88261_HMUTE_MASK);
 			reg_val |= read_val;
 
 			/* enable uls hmute */


### PR DESCRIPTION
As per the downstream code (aw882xx), we want the three bits AMPPD, PWDN, and HMUTE to be kept to their current value in the register. The masking logic to do that used an "OR" of the negated masks, which is wrong; it should be and "AND". With this patch we restore the broken invariant that the final value is assembled from complementary masks.